### PR TITLE
fixed localized link to microsoft docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ Use with the image control
 The complete example can be downloaded here: 
 https://github.com/TBertuzzi/Xamarin.Forms.PinchZoomImage/tree/master/PinchZoomImageSample
 
-Base on original docs : https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/app-fundamentals/gestures/pinch
+Base on original docs : https://docs.microsoft.com/xamarin/xamarin-forms/app-fundamentals/gestures/pinch


### PR DESCRIPTION
The link to the microsoft docs was localized to Português (Brasil) I changed it to a non locilized link.