### PR TITLE
1st double tap enlarges, 2nd double tap resets

### DIFF
--- a/Xamarin.Forms.PinchZoomImage/PinchZoom.cs
+++ b/Xamarin.Forms.PinchZoomImage/PinchZoom.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Forms.PinchZoomImage
         double startScale = 1;
         double xOffset = 0;
         double yOffset = 0;
+        bool SecondDoubleTapp = false; //boolean checking if the user doubletapped for the first time or second time
 
         public PinchZoom()
         {
@@ -147,7 +148,15 @@ namespace Xamarin.Forms.PinchZoomImage
 
             for (int i=0; i<10; i++)
             {
-                currentScale *= multiplicator;
+                if (!SecondDoubleTapp) //if it's not the second double tapp we enlarge the scale
+                {
+                    currentScale *= multiplicator;
+                }
+                else //if it's the second double tap we make the scale smaller again 
+                {
+                    currentScale /= multiplicator; 
+                }
+
                 double renderedX = Content.X + xOffset;
                 double deltaX = renderedX / Width;
                 double deltaWidth = Width / (Content.Width * startScale);
@@ -167,7 +176,14 @@ namespace Xamarin.Forms.PinchZoomImage
                 Content.Scale = currentScale;
                 await Task.Delay(10);
             }
-
+            if (!SecondDoubleTapp) // if this was the first double tapp then the next one is considered the second double tapp
+            {
+                SecondDoubleTapp = true;
+            }
+            else //reset the boolean 
+            {
+                SecondDoubleTapp = false;
+            }
             xOffset = Content.TranslationX;
             yOffset = Content.TranslationY;
         }


### PR DESCRIPTION
Hi! 

I used your Nuget to great succes thank you. the only thing I changed was this: 

I'm used to the user experience where my first double tap enlarges the picture, and my second double tap shrinks it again. 

I added this functionality to your code by 2 simple if statements and a boolean. 
- The boolean tells us if the user doubletapped for the first time or the second time 
- The first if statement either enlarges or shrinks according to the boolean 
- the second if statement updates the boolean to the new value 

I hope you consider these changes! Have a great day :)